### PR TITLE
Pulled in updates from mantid

### DIFF
--- a/common/ADARAPackets.cc
+++ b/common/ADARAPackets.cc
@@ -9,7 +9,7 @@ using namespace ADARA;
 
 static bool validate_status(uint16_t val)
 {
-	VariableStatus::Enum e = static_cast<VariableStatus::Enum>(val);
+	auto e = static_cast<VariableStatus::Enum>(val);
 
 	/* No default case so that we get warned when new status values
 	 * get added.
@@ -47,7 +47,7 @@ static bool validate_status(uint16_t val)
 
 static bool validate_severity(uint16_t val)
 {
-	VariableSeverity::Enum e = static_cast<VariableSeverity::Enum>(val);
+	auto e = static_cast<VariableSeverity::Enum>(val);
 
 	/* No default case so that we get warned when new severities get added.
 	 */
@@ -85,7 +85,7 @@ Packet::~Packet()
 /* -------------------------------------------------------------------- */
 
 RawDataPkt::RawDataPkt(const uint8_t *data, uint32_t len) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {
 	if (m_version == 0x00 && m_payload_len < (6 * sizeof(uint32_t))) {
 		std::stringstream ss;
@@ -115,7 +115,7 @@ RawDataPkt::RawDataPkt(const uint8_t *data, uint32_t len) :
 }
 
 RawDataPkt::RawDataPkt(const RawDataPkt &pkt) :
-	Packet(pkt), m_fields((const uint32_t *)payload())
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {}
 
 /* -------------------------------------------------------------------- */
@@ -262,7 +262,11 @@ SourceListPkt::SourceListPkt(const SourceListPkt &pkt) :
 /* -------------------------------------------------------------------- */
 
 BankedEventPkt::BankedEventPkt(const uint8_t *data, uint32_t len) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload())),
+	m_curEvent(nullptr), m_lastFieldIndex(0), m_curFieldIndex(0),
+	m_sourceStartIndex(0), m_bankCount(0), m_TOFOffset(0),
+	m_isCorrected(false), m_bankNum(0), m_bankStartIndex(0),
+	m_bankId(0), m_eventCount(0)
 {
 	if (m_version == 0x00 && m_payload_len < (4 * sizeof(uint32_t))) {
 		std::stringstream ss;
@@ -289,17 +293,142 @@ BankedEventPkt::BankedEventPkt(const uint8_t *data, uint32_t len) :
 			<< m_payload_len;
 		throw invalid_packet(ss.str());
 	}
+
+	m_lastFieldIndex = (payload_length() / 4) - 1;
 }
 
 BankedEventPkt::BankedEventPkt(const BankedEventPkt &pkt) :
-	Packet(pkt), m_fields((const uint32_t *)payload())
-{}
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload())),
+	m_curEvent(nullptr), m_lastFieldIndex(0), m_curFieldIndex(0),
+	m_sourceStartIndex(0), m_bankCount(0), m_TOFOffset(0),
+	m_isCorrected(false), m_bankNum(0), m_bankStartIndex(0),
+	m_bankId(0), m_eventCount(0)
+{
+	m_lastFieldIndex = (payload_length() / 4) - 1;
+}
+
+// The fact that events are wrapped up in banks which are wrapped up in
+// source sections is abstracted away (with the exception of checking the
+// COR flag and TOF offset fields for each source).  All we've got is
+// firstEvent() and nextEvent().  nextEvent() will be smart enough to skip
+// over the source section headers and bank headers.
+
+// A packet can have 0 or more sources and each source can have 0 or more
+// events.  That means the only payload we're guaranteed to have is the
+// first 4 fields.  After that, we've got to start checking against the
+// payload len...
+const Event *BankedEventPkt::firstEvent() const
+{
+	m_curEvent = nullptr;
+	m_curFieldIndex = 4;
+	while (m_curEvent == nullptr && m_curFieldIndex <= m_lastFieldIndex) {
+		// Start of a new source
+		firstEventInSource();
+	}
+
+	return m_curEvent;
+}
+
+const Event *BankedEventPkt::nextEvent() const
+{
+	// If we're NULL, it's because we've already incremented past the
+	// last event.
+	if (m_curEvent) {
+		m_curEvent = nullptr;
+		// Go to where the next event will start (if there is one)
+		m_curFieldIndex += 2;
+
+		// Have we passed the end of the bank?
+		if (m_curFieldIndex < (m_bankStartIndex + 2 + (2 * m_eventCount))) {
+			// This is the easy case - the next event is in the
+			// current bank
+			m_curEvent = reinterpret_cast<const Event *>(&m_fields[m_curFieldIndex]);
+		}
+		else {
+			m_bankNum++;
+			while (m_bankNum <= m_bankCount && m_curEvent == nullptr) {
+				firstEventInBank();
+				if (m_curEvent == nullptr) {
+					// Increment bankNum because there were no
+					// events in the bank we just tested
+					m_bankNum++;
+				}
+			}
+
+			// If we still haven't found an event, check for more
+			// source sections
+			while (m_curEvent == nullptr
+					&& m_curFieldIndex < m_lastFieldIndex) {
+				firstEventInSource();
+			}
+		}
+	}
+
+	return m_curEvent;
+}
+
+// Helper functions for firstEvent() & nextEvent()
+
+// Assumes m_curFieldIndex points to the start of a source section.
+// Sets m_curEvent to the first event in that source (or NULL if the
+// source is empty).  Sets m_curFieldIndex pointing at the event or at
+// the start of the next source if there were no events.
+void BankedEventPkt::firstEventInSource() const
+{
+	// index into m_fields for the start of this source
+	m_sourceStartIndex = m_curFieldIndex;
+	m_bankCount = m_fields[m_sourceStartIndex + 3];
+	if (m_bankCount > 0) {
+		// The != 0 comparison avoids a warning on MSVC about the
+		// performance of forcing a uint32_t to a bool
+		m_TOFOffset = ((m_fields[m_sourceStartIndex + 2]
+				& 0x7FFFFFFF) != 0);
+		m_isCorrected = ((m_fields[m_sourceStartIndex + 2]
+				& 0x80000000) != 0);
+		m_bankNum = 1; // banks are numbered from 1 to m_bankCount.
+		m_curFieldIndex = m_sourceStartIndex + 4;
+
+		while (m_bankNum <= m_bankCount && m_curEvent == nullptr) {
+			firstEventInBank();
+			if (m_curEvent == nullptr) {
+				// Increment bankNum because there were no
+				// events in the bank we just tested
+				m_bankNum++;
+			}
+		}
+	}
+	else {
+		// No banks in this source, skip to the next source
+		m_curFieldIndex += 4;
+		m_curEvent = nullptr;
+	}
+}
+
+// Assumes m_curFieldIndex points at the start of a bank.  Sets m_curEvent
+// to the first event in that bank (or NULL if the bank is empty).  Sets
+// m_curFieldIndex to the first event if it exists or to the start of the
+// next bank if the bank is empty, or to the start of the next source if it
+// was the last bank.
+void BankedEventPkt::firstEventInBank() const
+{
+	// index into m_fields for the start of this bank
+	m_bankStartIndex = m_curFieldIndex;
+	m_bankId = m_fields[m_bankStartIndex];
+	m_eventCount = m_fields[m_bankStartIndex + 1];
+	m_curFieldIndex = m_bankStartIndex + 2;
+	if (m_eventCount > 0) {
+		m_curEvent = reinterpret_cast<const Event *>(&m_fields[m_curFieldIndex]);
+	}
+	else {
+		m_curEvent = nullptr;
+	}
+}
 
 /* -------------------------------------------------------------------- */
 
 BankedEventStatePkt::BankedEventStatePkt(
 		const uint8_t *data, uint32_t len) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {
 	if (m_version == 0x00 && m_payload_len < (4 * sizeof(uint32_t))) {
 		std::stringstream ss;
@@ -321,13 +450,14 @@ BankedEventStatePkt::BankedEventStatePkt(
 }
 
 BankedEventStatePkt::BankedEventStatePkt(const BankedEventStatePkt &pkt) :
-	Packet(pkt), m_fields((const uint32_t *)payload())
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {}
 
 /* -------------------------------------------------------------------- */
 
 BeamMonitorPkt::BeamMonitorPkt(const uint8_t *data, uint32_t len) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload())),
+	m_sectionStartIndex(0), m_eventNum(0)
 {
 	if (m_version == 0x00 && m_payload_len < (4 * sizeof(uint32_t))) {
 		std::stringstream ss;
@@ -357,33 +487,108 @@ BeamMonitorPkt::BeamMonitorPkt(const uint8_t *data, uint32_t len) :
 }
 
 BeamMonitorPkt::BeamMonitorPkt(const BeamMonitorPkt &pkt) :
-	Packet(pkt), m_fields((const uint32_t *)payload())
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload())),
+	m_sectionStartIndex(0), m_eventNum(0)
 {}
+
+#define EVENT_COUNT_MASK	0x003FFFFF	// lower 22 bits
+
+// Returns true if there is a next section.  False if there isn't.
+bool BeamMonitorPkt::nextSection() const
+{
+	bool RV = false; // assume we're at the last section
+	unsigned newSectionStart;
+	if (m_sectionStartIndex == 0) {
+		newSectionStart = 4;
+	}
+	else {
+		unsigned eventCount =
+			m_fields[m_sectionStartIndex] & EVENT_COUNT_MASK;
+		newSectionStart = m_sectionStartIndex + 3 + eventCount;
+	}
+
+	if ((newSectionStart * 4) < m_payload_len) {
+		RV = true;
+		m_sectionStartIndex = newSectionStart;
+		m_eventNum = 0; // reset the counter for the nextEvent() function
+	}
+
+	return RV;
+}
+
+uint32_t BeamMonitorPkt::getSectionMonitorID() const
+{
+	// Monitor ID is the upper 10 bits
+	return (m_fields[m_sectionStartIndex] >> 22);
+}
+
+uint32_t BeamMonitorPkt::getSectionEventCount() const
+{
+	return m_fields[m_sectionStartIndex] & EVENT_COUNT_MASK;
+}
+
+uint32_t BeamMonitorPkt::getSectionSourceID() const
+{
+	return m_fields[m_sectionStartIndex + 1];
+}
+
+uint32_t BeamMonitorPkt::getSectionTOFOffset() const
+{
+	// need to mask off the high bit
+	return m_fields[m_sectionStartIndex + 2] & 0x7FFFFFFF;
+}
+
+bool BeamMonitorPkt::sectionTOFCorrected() const
+{
+	// only want the high bit
+	return ((m_fields[m_sectionStartIndex + 2] & 0x80000000) != 0);
+}
+
+#define CYCLE_MASK	0x7FE00000	// bits 30 to 21 (inclusive)
+#define TOF_MASK	0x001FFFFF	// bits 20 to 0 (inclusive)
+bool BeamMonitorPkt::nextEvent(
+		bool &risingEdge, uint32_t &cycle, uint32_t &tof) const
+{
+	bool RV = false;
+	if (m_sectionStartIndex != 0 && m_eventNum < getSectionEventCount()) {
+		uint32_t rawEvent =
+			m_fields[m_sectionStartIndex + 3 + m_eventNum];
+
+		risingEdge = ((rawEvent & 0x80000000) != 0);
+		cycle = (rawEvent & CYCLE_MASK) >> 21;
+		tof = (rawEvent & TOF_MASK);
+
+		m_eventNum++;
+		RV = true;
+	}
+
+	return RV;
+}
 
 /* -------------------------------------------------------------------- */
 
 PixelMappingPkt::PixelMappingPkt(const uint8_t *data, uint32_t len) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {}
 
 PixelMappingPkt::PixelMappingPkt(const PixelMappingPkt &pkt) :
-	Packet(pkt), m_fields((const uint32_t *)payload())
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {}
 
 /* -------------------------------------------------------------------- */
 
 PixelMappingAltPkt::PixelMappingAltPkt(const uint8_t *data, uint32_t len) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {}
 
 PixelMappingAltPkt::PixelMappingAltPkt(const PixelMappingAltPkt &pkt) :
-	Packet(pkt), m_fields((const uint32_t *)payload())
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {}
 
 /* -------------------------------------------------------------------- */
 
 RunStatusPkt::RunStatusPkt(const uint8_t *data, uint32_t len) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {
 	if (m_version == 0x00 && m_payload_len != (3 * sizeof(uint32_t))) {
 		std::stringstream ss;
@@ -414,7 +619,7 @@ RunStatusPkt::RunStatusPkt(const uint8_t *data, uint32_t len) :
 }
 
 RunStatusPkt::RunStatusPkt(const RunStatusPkt &pkt) :
-	Packet(pkt), m_fields((const uint32_t *)payload())
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {}
 
 /* -------------------------------------------------------------------- */
@@ -422,8 +627,8 @@ RunStatusPkt::RunStatusPkt(const RunStatusPkt &pkt) :
 RunInfoPkt::RunInfoPkt(const uint8_t *data, uint32_t len) :
 	Packet(data, len)
 {
-	uint32_t size = *(const uint32_t *) payload();
-	const char *xml = (const char *) payload() + sizeof(uint32_t);
+	uint32_t size = *reinterpret_cast<const uint32_t *>(payload());
+	const char *xml = reinterpret_cast<const char *>(payload()) + sizeof(uint32_t);
 
 	if (m_version == 0x00 && m_payload_len < sizeof(uint32_t)) {
 		std::stringstream ss;
@@ -494,8 +699,8 @@ RunInfoPkt::RunInfoPkt(const RunInfoPkt &pkt) :
 TransCompletePkt::TransCompletePkt(const uint8_t *data, uint32_t len) :
 	Packet(data, len)
 {
-	uint32_t size = *(const uint32_t *) payload();
-	const char *reason = (const char *) payload() + sizeof(uint32_t);
+	uint32_t size = *reinterpret_cast<const uint32_t *>(payload());
+	const char *reason = reinterpret_cast<const char *>(payload()) + sizeof(uint32_t);
 
 	if (m_version == 0x00 && m_payload_len < sizeof(uint32_t)) {
 		std::stringstream ss;
@@ -595,7 +800,7 @@ ClientHelloPkt::ClientHelloPkt(const uint8_t *data, uint32_t len) :
 		throw invalid_packet(ss.str());
 	}
 
-	const uint32_t *fields = (const uint32_t *) payload();
+	const auto *fields = reinterpret_cast<const uint32_t *>(payload());
 
 	m_reqStart = fields[0];
 
@@ -610,7 +815,7 @@ ClientHelloPkt::ClientHelloPkt(const ClientHelloPkt &pkt) :
 /* -------------------------------------------------------------------- */
 
 AnnotationPkt::AnnotationPkt(const uint8_t *data, uint32_t len) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {
 	if (m_version == 0x00 && m_payload_len < (2 * sizeof(uint32_t))) {
 		std::stringstream ss;
@@ -631,7 +836,7 @@ AnnotationPkt::AnnotationPkt(const uint8_t *data, uint32_t len) :
 	}
 
 	uint16_t size = m_fields[0] & 0xffff;
-	const char *comment = (const char *) &m_fields[2];
+	const char *comment = reinterpret_cast<const char *>(&m_fields[2]);
 	if (m_version == 0x00
 			&& m_payload_len < (size + (2 * sizeof(uint32_t)))) {
 		std::stringstream ss;
@@ -674,13 +879,13 @@ AnnotationPkt::AnnotationPkt(const uint8_t *data, uint32_t len) :
 }
 
 AnnotationPkt::AnnotationPkt(const AnnotationPkt &pkt) :
-	Packet(pkt), m_fields((const uint32_t *)payload())
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {}
 
 /* -------------------------------------------------------------------- */
 
 SyncPkt::SyncPkt(const uint8_t *data, uint32_t len) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {
 	if (m_version == 0x00 && m_payload_len < 28) {
 		std::stringstream ss;
@@ -700,13 +905,13 @@ SyncPkt::SyncPkt(const uint8_t *data, uint32_t len) :
 		throw invalid_packet(ss.str());
 	}
 
-	const char *signature = (const char *) &m_fields[0];
+	const char *signature = reinterpret_cast<const char *>(&m_fields[0]);
 	m_signature.assign(signature, 16);
 
-	m_offset = *((uint64_t *) &m_fields[4]);
+	m_offset = *(reinterpret_cast<const uint64_t *>(&m_fields[4]));
 
 	uint32_t size = m_fields[6];
-	const char *comment = (const char *) &m_fields[7];
+	const char *comment = reinterpret_cast<const char *>(&m_fields[7]);
 	if (m_version == 0x00 && m_payload_len < (size + 28)) {
 		std::stringstream ss;
 		ss << ( (uint32_t) (m_pulseId >> 32) )
@@ -801,8 +1006,8 @@ GeometryPkt::GeometryPkt(const uint8_t *data, uint32_t len) :
 		throw invalid_packet(ss.str());
 	}
 
-	uint32_t size = *(const uint32_t *) payload();
-	const char *xml = (const char *) payload() + sizeof(uint32_t);
+	uint32_t size = *reinterpret_cast<const uint32_t *>(payload());
+	const char *xml = reinterpret_cast<const char *>(payload()) + sizeof(uint32_t);
 	if (m_version == 0x00 && m_payload_len < (size + sizeof(uint32_t))) {
 		std::stringstream ss;
 		ss << ( (uint32_t) (m_pulseId >> 32) )
@@ -854,8 +1059,8 @@ GeometryPkt::GeometryPkt(const GeometryPkt &pkt) :
 BeamlineInfoPkt::BeamlineInfoPkt(const uint8_t *data, uint32_t len) :
 	Packet(data, len)
 {
-	const char *info = (const char *) payload() + sizeof(uint32_t);
-	uint32_t sizes = *(const uint32_t *) payload();
+	const char *info = reinterpret_cast<const char *>(payload()) + sizeof(uint32_t);
+	uint32_t sizes = *reinterpret_cast<const uint32_t *>(payload());
 	uint32_t id_len, shortName_len, longName_len, info_len;
 
 	if (m_version == 0x00 && m_payload_len < sizeof(uint32_t)) {
@@ -969,7 +1174,7 @@ BeamlineInfoPkt::BeamlineInfoPkt(const BeamlineInfoPkt &pkt) :
 
 BeamMonitorConfigPkt::BeamMonitorConfigPkt(const uint8_t *data,
 		uint32_t len) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {
 	// Size of Beam Monitor Config Section, Including:
 	// U32( ID, TOF Offset, Max TOF, Histo Bin Size ) + Double( Distance )
@@ -1013,7 +1218,7 @@ BeamMonitorConfigPkt::BeamMonitorConfigPkt(const uint8_t *data,
 
 BeamMonitorConfigPkt::BeamMonitorConfigPkt(
 		const BeamMonitorConfigPkt &pkt ) :
-	Packet(pkt), m_fields((const uint32_t *)payload()),
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload())),
 		m_sectionSize(pkt.m_sectionSize)
 {}
 
@@ -1021,8 +1226,8 @@ BeamMonitorConfigPkt::BeamMonitorConfigPkt(
 
 DetectorBankSetsPkt::DetectorBankSetsPkt(const uint8_t *data,
 		uint32_t len) :
-	Packet(data, len), m_fields((const uint32_t *)payload()),
-	m_sectionOffsets(NULL), m_after_banks_offset(NULL)
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload())),
+	m_sectionOffsets(nullptr), m_after_banks_offset(nullptr)
 {
 	// Get Number of Detector Bank Sets...
 	//    - Basic Packet Size Sanity Check
@@ -1090,9 +1295,9 @@ DetectorBankSetsPkt::DetectorBankSetsPkt(const uint8_t *data,
 			ss << " baseSectionOffsetNoBanks=" << baseSectionOffsetNoBanks;
 			ss << " payload_len=" << m_payload_len;
 			delete[] m_sectionOffsets;
-			m_sectionOffsets = (uint32_t *) NULL;
+			m_sectionOffsets = nullptr;
 			delete[] m_after_banks_offset;
-			m_after_banks_offset = (uint32_t *) NULL;
+			m_after_banks_offset = nullptr;
 			throw invalid_packet(ss.str());
 		}
 		else if ( m_version > ADARA::PacketType::DETECTOR_BANK_SETS_VERSION
@@ -1108,9 +1313,9 @@ DetectorBankSetsPkt::DetectorBankSetsPkt(const uint8_t *data,
 			ss << " baseSectionOffsetNoBanks=" << baseSectionOffsetNoBanks;
 			ss << " payload_len=" << m_payload_len;
 			delete[] m_sectionOffsets;
-			m_sectionOffsets = (uint32_t *) NULL;
+			m_sectionOffsets = nullptr;
 			delete[] m_after_banks_offset;
-			m_after_banks_offset = (uint32_t *) NULL;
+			m_after_banks_offset = nullptr;
 			throw invalid_packet(ss.str());
 		}
 
@@ -1137,9 +1342,9 @@ DetectorBankSetsPkt::DetectorBankSetsPkt(const uint8_t *data,
 		ss << " final sectionOffset=" << sectionOffset;
 		ss << " payload_len=" << m_payload_len;
 		delete[] m_sectionOffsets;
-		m_sectionOffsets = (uint32_t *) NULL;
+		m_sectionOffsets = nullptr;
 		delete[] m_after_banks_offset;
-		m_after_banks_offset = (uint32_t *) NULL;
+		m_after_banks_offset = nullptr;
 		throw invalid_packet(ss.str());
 	}
 	else if ( m_version > ADARA::PacketType::DETECTOR_BANK_SETS_VERSION
@@ -1153,17 +1358,17 @@ DetectorBankSetsPkt::DetectorBankSetsPkt(const uint8_t *data,
 		ss << " final sectionOffset=" << sectionOffset;
 		ss << " payload_len=" << m_payload_len;
 		delete[] m_sectionOffsets;
-		m_sectionOffsets = (uint32_t *) NULL;
+		m_sectionOffsets = nullptr;
 		delete[] m_after_banks_offset;
-		m_after_banks_offset = (uint32_t *) NULL;
+		m_after_banks_offset = nullptr;
 		throw invalid_packet(ss.str());
 	}
 }
 
 DetectorBankSetsPkt::DetectorBankSetsPkt(
 		const DetectorBankSetsPkt &pkt ) :
-	Packet(pkt), m_fields((const uint32_t *)payload()),
-	m_sectionOffsets(NULL), m_after_banks_offset(NULL)
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload())),
+	m_sectionOffsets(nullptr), m_after_banks_offset(nullptr)
 {
 	uint32_t numSets = detBankSetCount();
 
@@ -1221,7 +1426,7 @@ DeviceDescriptorPkt::DeviceDescriptorPkt(
 	const uint8_t *data, uint32_t len) :
 	Packet(data, len)
 {
-	const uint32_t *fields = (const uint32_t *) payload();
+	const auto *fields = reinterpret_cast<const uint32_t *>(payload());
 	uint32_t size;
 
 	if (m_version == 0x00 && m_payload_len < (2 * sizeof(uint32_t))) {
@@ -1243,7 +1448,7 @@ DeviceDescriptorPkt::DeviceDescriptorPkt(
 	}
 
 	size = fields[1];
-	const char *desc = (const char *) &fields[2];
+	const char *desc = reinterpret_cast<const char *>(&fields[2]);
 	if (m_version == 0x00
 			&& m_payload_len < (size + (2 * sizeof(uint32_t)))) {
 		std::stringstream ss;
@@ -1288,7 +1493,7 @@ DeviceDescriptorPkt::DeviceDescriptorPkt(
 	 * rather than object construction; the user may not care.
 	 */
 	m_devId = fields[0];
-	m_desc.assign((const char *) &fields[2], size);
+	m_desc.assign(reinterpret_cast<const char *>(&fields[2]), size);
 }
 
 DeviceDescriptorPkt::DeviceDescriptorPkt(const DeviceDescriptorPkt &pkt) :
@@ -1298,7 +1503,7 @@ DeviceDescriptorPkt::DeviceDescriptorPkt(const DeviceDescriptorPkt &pkt) :
 /* -------------------------------------------------------------------- */
 
 VariableU32Pkt::VariableU32Pkt(const uint8_t *data, uint32_t len) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {
 	if (m_version == 0x00 && m_payload_len != (4 * sizeof(uint32_t))) {
 		std::stringstream ss;
@@ -1338,13 +1543,13 @@ VariableU32Pkt::VariableU32Pkt(const uint8_t *data, uint32_t len) :
 }
 
 VariableU32Pkt::VariableU32Pkt(const VariableU32Pkt &pkt) :
-	Packet(pkt), m_fields((const uint32_t *)payload())
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {}
 
 /* -------------------------------------------------------------------- */
 
 VariableDoublePkt::VariableDoublePkt(const uint8_t *data, uint32_t len) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {
 	if (m_version == 0x00
 			&& m_payload_len
@@ -1386,13 +1591,13 @@ VariableDoublePkt::VariableDoublePkt(const uint8_t *data, uint32_t len) :
 }
 
 VariableDoublePkt::VariableDoublePkt(const VariableDoublePkt &pkt) :
-	Packet(pkt), m_fields((const uint32_t *)payload())
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {}
 
 /* -------------------------------------------------------------------- */
 
 VariableStringPkt::VariableStringPkt(const uint8_t *data, uint32_t len) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {
 	uint32_t size;
 
@@ -1415,7 +1620,7 @@ VariableStringPkt::VariableStringPkt(const uint8_t *data, uint32_t len) :
 	}
 
 	size = m_fields[3];
-	const char *str = (const char *) &m_fields[4];
+	const char *str = reinterpret_cast<const char *>(&m_fields[4]);
 	if (m_version == 0x00
 			&& m_payload_len < (size + (4 * sizeof(uint32_t)))) {
 		std::stringstream ss;
@@ -1478,18 +1683,18 @@ VariableStringPkt::VariableStringPkt(const uint8_t *data, uint32_t len) :
 	/* TODO it would be better to create the string on access
 	 * rather than object construction; the user may not care.
 	 */
-	m_val.assign((const char *) &m_fields[4], size);
+	m_val.assign(reinterpret_cast<const char *>(&m_fields[4]), size);
 }
 
 VariableStringPkt::VariableStringPkt(const VariableStringPkt &pkt) :
-	Packet(pkt), m_fields((const uint32_t *)payload()), m_val(pkt.m_val)
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload())), m_val(pkt.m_val)
 {}
 
 /* -------------------------------------------------------------------- */
 
 VariableU32ArrayPkt::VariableU32ArrayPkt(
 		const uint8_t *data, uint32_t len ) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {
 	uint32_t count;
 	size_t size;
@@ -1560,18 +1765,18 @@ VariableU32ArrayPkt::VariableU32ArrayPkt(
 	 */
 	m_val = std::vector<uint32_t>( count );
 	memcpy(const_cast<uint32_t *> (m_val.data()),
-		(const uint32_t *) &m_fields[4], count * sizeof(uint32_t));
+		reinterpret_cast<const uint32_t *>(&m_fields[4]), count * sizeof(uint32_t));
 }
 
 VariableU32ArrayPkt::VariableU32ArrayPkt(const VariableU32ArrayPkt &pkt) :
-	Packet(pkt), m_fields((const uint32_t *)payload()), m_val(pkt.m_val)
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload())), m_val(pkt.m_val)
 {}
 
 /* -------------------------------------------------------------------- */
 
 VariableDoubleArrayPkt::VariableDoubleArrayPkt(
 		const uint8_t *data, uint32_t len ) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {
 	uint32_t count;
 	size_t size;
@@ -1642,18 +1847,18 @@ VariableDoubleArrayPkt::VariableDoubleArrayPkt(
 	 */
 	m_val = std::vector<double>( count );
 	memcpy(const_cast<double *> (m_val.data()),
-		(const double *) &m_fields[4], count * sizeof(double));
+		reinterpret_cast<const double *>(&m_fields[4]), count * sizeof(double));
 }
 
 VariableDoubleArrayPkt::VariableDoubleArrayPkt(
 		const VariableDoubleArrayPkt &pkt ) :
-	Packet(pkt), m_fields((const uint32_t *)payload()), m_val(pkt.m_val)
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload())), m_val(pkt.m_val)
 {}
 
 /* -------------------------------------------------------------------- */
 
 MultVariableU32Pkt::MultVariableU32Pkt(const uint8_t *data, uint32_t len) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {
 	uint32_t numVals;
 	size_t size;
@@ -1724,7 +1929,7 @@ MultVariableU32Pkt::MultVariableU32Pkt(const uint8_t *data, uint32_t len) :
 
 	// Copy Over NumValues TOF and U32 Values from Payload...
 
-	const uint32_t *ptr = (const uint32_t *) &m_fields[4];
+	const uint32_t *ptr = reinterpret_cast<const uint32_t *>(&m_fields[4]);
 
 	/* TODO it would be better to create the array on access
 	 * rather than object construction; the user may not care.
@@ -1741,7 +1946,7 @@ MultVariableU32Pkt::MultVariableU32Pkt(const uint8_t *data, uint32_t len) :
 }
 
 MultVariableU32Pkt::MultVariableU32Pkt(const MultVariableU32Pkt &pkt) :
-	Packet(pkt), m_fields((const uint32_t *)payload()),
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload())),
 	m_vals(pkt.m_vals), m_tofs(pkt.m_tofs)
 {}
 
@@ -1749,7 +1954,7 @@ MultVariableU32Pkt::MultVariableU32Pkt(const MultVariableU32Pkt &pkt) :
 
 MultVariableDoublePkt::MultVariableDoublePkt(
 		const uint8_t *data, uint32_t len) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {
 	uint32_t numVals;
 	size_t size;
@@ -1826,7 +2031,7 @@ MultVariableDoublePkt::MultVariableDoublePkt(
 
 	// Copy Over NumValues TOF and Double Values from Payload...
 
-	const uint32_t *ptr = (const uint32_t *) &m_fields[4];
+	const uint32_t *ptr = reinterpret_cast<const uint32_t *>(&m_fields[4]);
 
 	/* TODO it would be better to create the array on access
 	 * rather than object construction; the user may not care.
@@ -1838,13 +2043,13 @@ MultVariableDoublePkt::MultVariableDoublePkt(
 		m_tofs.push_back( *ptr++ );
 
 		// Next Double Value...
-		m_vals.push_back( *((double *)ptr++) );
+		m_vals.push_back( *(reinterpret_cast<const double *>(ptr++)) );
 	}
 }
 
 MultVariableDoublePkt::MultVariableDoublePkt(
 		const MultVariableDoublePkt &pkt) :
-	Packet(pkt), m_fields((const uint32_t *)payload()),
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload())),
 	m_vals(pkt.m_vals), m_tofs(pkt.m_tofs)
 {}
 
@@ -1852,7 +2057,7 @@ MultVariableDoublePkt::MultVariableDoublePkt(
 
 MultVariableStringPkt::MultVariableStringPkt(
 		const uint8_t *data, uint32_t len) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {
 	uint32_t numVals;
 	uint32_t size;
@@ -1923,7 +2128,7 @@ MultVariableStringPkt::MultVariableStringPkt(
 
 	// Check & Copy Over NumValues Strings from Payload...
 
-	const uint32_t *ptr = (const uint32_t *) &m_fields[4];
+	const uint32_t *ptr = reinterpret_cast<const uint32_t *>(&m_fields[4]);
 	uint32_t payload_remaining = m_payload_len - (4 * sizeof(uint32_t));
 
 	for ( uint32_t i=0 ; i < numVals ; i++ ) {
@@ -1935,7 +2140,7 @@ MultVariableStringPkt::MultVariableStringPkt(
 		size = *ptr++;
 
 		// Next String...
-		const char *str = (const char *) ptr;
+		const char *str = reinterpret_cast<const char *>(ptr);
 
 		if (m_version == 0x00
 				&& payload_remaining < (size + (2 * sizeof(uint32_t)))) {
@@ -1993,7 +2198,7 @@ MultVariableStringPkt::MultVariableStringPkt(
 
 MultVariableStringPkt::MultVariableStringPkt(
 		const MultVariableStringPkt &pkt) :
-	Packet(pkt), m_fields((const uint32_t *)payload()),
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload())),
 	m_vals(pkt.m_vals), m_tofs(pkt.m_tofs)
 {}
 
@@ -2001,7 +2206,7 @@ MultVariableStringPkt::MultVariableStringPkt(
 
 MultVariableU32ArrayPkt::MultVariableU32ArrayPkt(
 		const uint8_t *data, uint32_t len ) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {
 	uint32_t numVals;
 	size_t size;
@@ -2075,7 +2280,7 @@ MultVariableU32ArrayPkt::MultVariableU32ArrayPkt(
 
 	// Check & Copy Over NumValues U32 Arrays from Payload...
 
-	const uint32_t *ptr = (const uint32_t *) &m_fields[4];
+	const uint32_t *ptr = reinterpret_cast<const uint32_t *>(&m_fields[4]);
 	uint32_t payload_remaining = m_payload_len - (4 * sizeof(uint32_t));
 
 	for ( uint32_t i=0 ; i < numVals ; i++ ) {
@@ -2087,7 +2292,7 @@ MultVariableU32ArrayPkt::MultVariableU32ArrayPkt(
 		size = *ptr++;
 
 		// Next U32 Array...
-		const uint32_t *arr = (const uint32_t *) ptr;
+		const uint32_t *arr = reinterpret_cast<const uint32_t *>(ptr);
 
 		if (m_version == 0x00
 				&& payload_remaining < (( size + 2 ) * sizeof(uint32_t))) {
@@ -2125,7 +2330,7 @@ MultVariableU32ArrayPkt::MultVariableU32ArrayPkt(
 
 MultVariableU32ArrayPkt::MultVariableU32ArrayPkt(
 		const MultVariableU32ArrayPkt &pkt) :
-	Packet(pkt), m_fields((const uint32_t *)payload()),
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload())),
 	m_vals(pkt.m_vals), m_tofs(pkt.m_tofs)
 {}
 
@@ -2133,7 +2338,7 @@ MultVariableU32ArrayPkt::MultVariableU32ArrayPkt(
 
 MultVariableDoubleArrayPkt::MultVariableDoubleArrayPkt(
 		const uint8_t *data, uint32_t len ) :
-	Packet(data, len), m_fields((const uint32_t *)payload())
+	Packet(data, len), m_fields(reinterpret_cast<const uint32_t *>(payload()))
 {
 	uint32_t numVals;
 	size_t size;
@@ -2209,7 +2414,7 @@ MultVariableDoubleArrayPkt::MultVariableDoubleArrayPkt(
 
 	// Check & Copy Over NumValues Double Arrays from Payload...
 
-	const uint32_t *ptr = (const uint32_t *) &m_fields[4];
+	const uint32_t *ptr = reinterpret_cast<const uint32_t *>(&m_fields[4]);
 	uint32_t payload_remaining = m_payload_len - (4 * sizeof(uint32_t));
 
 	for ( uint32_t i=0 ; i < numVals ; i++ ) {
@@ -2221,7 +2426,7 @@ MultVariableDoubleArrayPkt::MultVariableDoubleArrayPkt(
 		size = *ptr++;
 
 		// Next Double Array...
-		const double *arr = (const double *) ptr;
+		const double *arr = reinterpret_cast<const double *>(ptr);
 
 		if (m_version == 0x00
 				&& payload_remaining
@@ -2266,7 +2471,7 @@ MultVariableDoubleArrayPkt::MultVariableDoubleArrayPkt(
 
 MultVariableDoubleArrayPkt::MultVariableDoubleArrayPkt(
 		const MultVariableDoubleArrayPkt &pkt ) :
-	Packet(pkt), m_fields((const uint32_t *)payload()),
+	Packet(pkt), m_fields(reinterpret_cast<const uint32_t *>(payload())),
 	m_vals(pkt.m_vals), m_tofs(pkt.m_tofs)
 {}
 

--- a/common/ADARAPackets.h
+++ b/common/ADARAPackets.h
@@ -17,7 +17,7 @@ namespace ADARA {
 class PacketHeader {
 public:
 	PacketHeader(const uint8_t *data) {
-		const uint32_t *field = (const uint32_t *) data;
+		const uint32_t *field = reinterpret_cast<const uint32_t *>(data);
 
 		m_payload_len = field[0];
 
@@ -37,15 +37,15 @@ public:
 		m_pulseId |= field[3];
 	}
 
-	uint32_t type(void) const { return m_type; }
-	PacketType::Type base_type(void) const { return m_base_type; }
-	PacketType::Version version(void) const { return m_version; }
-	uint32_t payload_length(void) const { return m_payload_len; }
-	const struct timespec &timestamp(void) const { return m_timestamp; }
-	uint64_t pulseId(void) const { return m_pulseId; }
-	uint32_t packet_length(void) const { return m_payload_len + 16; }
+	uint32_t type() const { return m_type; }
+	PacketType::Type base_type() const { return m_base_type; }
+	PacketType::Version version() const { return m_version; }
+	uint32_t payload_length() const { return m_payload_len; }
+	const struct timespec &timestamp() const { return m_timestamp; }
+	uint64_t pulseId() const { return m_pulseId; }
+	uint32_t packet_length() const { return m_payload_len + 16; }
 
-	static uint32_t header_length(void) { return 16; }
+	static uint32_t header_length() { return 16; }
 
 protected:
 	uint32_t m_payload_len;
@@ -66,8 +66,8 @@ public:
 
 	virtual ~Packet();
 
-	const uint8_t *packet(void) const { return m_data; }
-	const uint8_t *payload(void) const {
+	const uint8_t *packet() const { return m_data; }
+	const uint8_t *payload() const {
 		return m_data + header_length();
 	}
 
@@ -107,41 +107,41 @@ class RawDataPkt : public Packet {
 public:
 	RawDataPkt(const RawDataPkt &pkt);
 
-	uint32_t sourceID(void) const { return m_fields[0]; }
-	bool endOfPulse(void) const { return !!(m_fields[1] & 0x80000000); }
-	uint32_t pulseSeq(void) const { return (m_fields[1] >> 16) & 0x7fff; }
-	uint32_t maxPulseSeq(void) const { return ( 0x7fff + 1 ); }
-	uint32_t sourceSeq(void) const { return m_fields[1] & 0xffff; }
-	uint32_t maxSourceSeq(void) const { return ( 0xffff + 1 ); }
+	uint32_t sourceID() const { return m_fields[0]; }
+	bool endOfPulse() const { return !!(m_fields[1] & 0x80000000); }
+	uint32_t pulseSeq() const { return (m_fields[1] >> 16) & 0x7fff; }
+	uint32_t maxPulseSeq() const { return ( 0x7fff + 1 ); }
+	uint32_t sourceSeq() const { return m_fields[1] & 0xffff; }
+	uint32_t maxSourceSeq() const { return ( 0xffff + 1 ); }
 
-	bool gotDataFlags(void) const { return m_version >= 0x01; }
-	uint32_t dataFlags(void) const {
+	bool gotDataFlags() const { return m_version >= 0x01; }
+	uint32_t dataFlags() const {
 		if ( gotDataFlags() )
 			return (m_fields[2] >> 27) & 0x1f;
 		else return 0;
 	}
-	PulseFlavor::Enum flavor(void) const {
+	PulseFlavor::Enum flavor() const {
 		return static_cast<PulseFlavor::Enum>
 						((m_fields[2] >> 24) & 0x7);
 	}
-	uint32_t pulseCharge(void) const { return m_fields[2] & 0x00ffffff; }
+	uint32_t pulseCharge() const { return m_fields[2] & 0x00ffffff; }
 
-	bool badVeto(void) const { return !!(m_fields[3] & 0x80000000); }
-	bool badCycle(void) const { return !!(m_fields[3] & 0x40000000); }
-	uint8_t timingStatus(void) const {
+	bool badVeto() const { return !!(m_fields[3] & 0x80000000); }
+	bool badCycle() const { return !!(m_fields[3] & 0x40000000); }
+	uint8_t timingStatus() const {
 		return (uint8_t) (m_fields[3] >> 22);
 	}
-	uint16_t vetoFlags(void) const { return (m_fields[3] >> 10) & 0xfff; }
-	uint16_t cycle(void) const { return m_fields[3] & 0x3ff; }
+	uint16_t vetoFlags() const { return (m_fields[3] >> 10) & 0xfff; }
+	uint16_t cycle() const { return m_fields[3] & 0x3ff; }
 
-	uint32_t intraPulseTime(void) const { return m_fields[4]; }
+	uint32_t intraPulseTime() const { return m_fields[4]; }
 
-	bool tofCorrected(void) const { return !!(m_fields[5] & 0x80000000); }
-	uint32_t tofOffset(void) const { return m_fields[5] & 0x7fffffff; }
-	uint32_t tofField(void) const { return m_fields[5]; }
+	bool tofCorrected() const { return !!(m_fields[5] & 0x80000000); }
+	uint32_t tofOffset() const { return m_fields[5] & 0x7fffffff; }
+	uint32_t tofField() const { return m_fields[5]; }
 
-	const Event *events(void) const { return (const Event *) &m_fields[6]; }
-	uint32_t num_events(void) const {
+	const Event *events() const { return reinterpret_cast<const Event *>(&m_fields[6]); }
+	uint32_t num_events() const {
 		return (m_payload_len - 24) / (uint32_t) (2 * sizeof(uint32_t));
 	}
 
@@ -167,43 +167,43 @@ class RTDLPkt : public Packet {
 public:
 	RTDLPkt(const RTDLPkt &pkt);
 
-	bool gotDataFlags(void) const { return m_version >= 0x01; }
-	uint32_t dataFlags(void) const {
+	bool gotDataFlags() const { return m_version >= 0x01; }
+	uint32_t dataFlags() const {
 		if ( gotDataFlags() )
 			return (m_fields[0] >> 27) & 0x1f;
 		else return 0;
 	}
 
-	PulseFlavor::Enum flavor(void) const {
+	PulseFlavor::Enum flavor() const {
 		return static_cast<PulseFlavor::Enum>
 						((m_fields[0] >> 24) & 0x7);
 	}
 
-	uint32_t pulseCharge(void) const { return m_fields[0] & 0x00ffffff; }
+	uint32_t pulseCharge() const { return m_fields[0] & 0x00ffffff; }
 
 	void setPulseCharge(uint32_t pulseCharge) {
 		m_fields[0] &= 0xff000000;
 		m_fields[0] |= pulseCharge & 0x00ffffff;
 	}
 
-	bool badVeto(void) const { return !!(m_fields[1] & 0x80000000); }
-	bool badCycle(void) const { return !!(m_fields[1] & 0x40000000); }
-	uint8_t timingStatus(void) const {
+	bool badVeto() const { return !!(m_fields[1] & 0x80000000); }
+	bool badCycle() const { return !!(m_fields[1] & 0x40000000); }
+	uint8_t timingStatus() const {
 		return (uint8_t) (m_fields[1] >> 22);
 	}
 
-	uint16_t vetoFlags(void) const { return (m_fields[1] >> 10) & 0xfff; }
+	uint16_t vetoFlags() const { return (m_fields[1] >> 10) & 0xfff; }
 
 	void setVetoFlags(uint16_t vetoFlags) {
 		m_fields[1] &= 0xffc003ff;
 		m_fields[1] |= ( vetoFlags & 0xfff ) << 10;
 	}
 
-	uint16_t cycle(void) const { return m_fields[1] & 0x3ff; }
-	uint32_t intraPulseTime(void) const { return m_fields[2]; }
-	bool tofCorrected(void) const { return !!(m_fields[3] & 0x80000000); }
-	uint32_t tofOffset(void) const { return m_fields[3] & 0x7fffffff; }
-	uint32_t ringPeriod(void) const { return m_fields[4] & 0xffffff; }
+	uint16_t cycle() const { return m_fields[1] & 0x3ff; }
+	uint32_t intraPulseTime() const { return m_fields[2]; }
+	bool tofCorrected() const { return !!(m_fields[3] & 0x80000000); }
+	uint32_t tofOffset() const { return m_fields[3] & 0x7fffffff; }
+	uint32_t ringPeriod() const { return m_fields[4] & 0xffffff; }
 
 	// accessor methods for optional FNA/Frame Data fields
 
@@ -238,8 +238,8 @@ class SourceListPkt : public Packet {
 public:
 	SourceListPkt(const SourceListPkt &pkt);
 
-	const uint32_t *ids(void) const { return (const uint32_t *) payload(); }
-	uint32_t num_ids(void) const {
+	const uint32_t *ids() const { return reinterpret_cast<const uint32_t *>(payload()); }
+	uint32_t num_ids() const {
 		return (uint32_t) payload_length() / (uint32_t) sizeof(uint32_t);
 	}
 
@@ -267,18 +267,45 @@ class BankedEventPkt : public Packet {
 public:
 	BankedEventPkt(const BankedEventPkt &pkt);
 
-	uint32_t pulseCharge(void) const { return m_fields[0]; }
-	uint32_t pulseEnergy(void) const { return m_fields[1]; }
-	uint32_t cycle(void) const { return m_fields[2]; }
-	uint32_t vetoFlags(void) const { return (m_fields[3] >> 20) & 0xfff; }
-	uint32_t flags(void) const { return m_fields[3] & 0xfffff; }
+	uint32_t pulseCharge() const { return m_fields[0]; }
+	uint32_t pulseEnergy() const { return m_fields[1]; }
+	uint32_t cycle() const { return m_fields[2]; }
+	uint32_t vetoFlags() const { return (m_fields[3] >> 20) & 0xfff; }
+	uint32_t flags() const { return m_fields[3] & 0xfffff; }
 
-	// TODO implment bank/event accessors
+	// The source, bank and event accessors all return NULL if we've
+	// incremented past the end of the packet's data.
+	const Event *firstEvent() const;
+	const Event *nextEvent() const;
+	bool getSourceCORFlag() const { return m_isCorrected; }
+	uint32_t getSourceTOFOffset() const { return m_TOFOffset; }
+	uint32_t curBankId() const { return m_bankId; }
+	uint32_t curEventCount() const { return m_eventCount; }
 
 private:
 	const uint32_t *m_fields;
 
+	mutable const Event *m_curEvent;
+	mutable unsigned m_lastFieldIndex;	// index into m_fields for the last valid field in the packet
+	mutable unsigned m_curFieldIndex;	// where we currently are in the packet
+
+	// Data about the current source section
+	mutable unsigned m_sourceStartIndex;	// index into m_fields for the start of this source
+	mutable uint32_t m_bankCount;
+	mutable uint32_t m_TOFOffset;
+	mutable bool m_isCorrected;
+	mutable unsigned m_bankNum;		// which bank are we currently in (relative to the start of the section)
+
+	// Data about the current bank
+	mutable unsigned m_bankStartIndex;	// index into m_fields for the start of this bank
+	mutable uint32_t m_bankId;
+	mutable uint32_t m_eventCount;
+
 	BankedEventPkt(const uint8_t *data, uint32_t len);
+
+	// Two helper functions for firstEvent() & nextEvent()
+	void firstEventInSource() const;
+	void firstEventInBank() const;
 
 	friend class Parser;
 };
@@ -287,11 +314,11 @@ class BankedEventStatePkt : public Packet {
 public:
 	BankedEventStatePkt(const BankedEventStatePkt &pkt);
 
-	uint32_t pulseCharge(void) const { return m_fields[0]; }
-	uint32_t pulseEnergy(void) const { return m_fields[1]; }
-	uint32_t cycle(void) const { return m_fields[2]; }
-	uint32_t vetoFlags(void) const { return (m_fields[3] >> 20) & 0xfff; }
-	uint32_t flags(void) const { return m_fields[3] & 0xfffff; }
+	uint32_t pulseCharge() const { return m_fields[0]; }
+	uint32_t pulseEnergy() const { return m_fields[1]; }
+	uint32_t cycle() const { return m_fields[2]; }
+	uint32_t vetoFlags() const { return (m_fields[3] >> 20) & 0xfff; }
+	uint32_t flags() const { return m_fields[3] & 0xfffff; }
 
 	// TODO implment bank/event accessors
 
@@ -307,16 +334,30 @@ class BeamMonitorPkt : public Packet {
 public:
 	BeamMonitorPkt(const BeamMonitorPkt &pkt);
 
-	uint32_t pulseCharge(void) const { return m_fields[0]; }
-	uint32_t pulseEnergy(void) const { return m_fields[1]; }
-	uint32_t cycle(void) const { return m_fields[2]; }
-	uint32_t vetoFlags(void) const { return (m_fields[3] >> 20) & 0xfff; }
-	uint32_t flags(void) const { return m_fields[3] & 0xfffff; }
+	uint32_t pulseCharge() const { return m_fields[0]; }
+	uint32_t pulseEnergy() const { return m_fields[1]; }
+	uint32_t cycle() const { return m_fields[2]; }
+	uint32_t vetoFlags() const { return (m_fields[3] >> 20) & 0xfff; }
+	uint32_t flags() const { return m_fields[3] & 0xfffff; }
 
-	// TODO implment monitor/event accessors
+	bool nextSection() const;	// iterate over the sections in the packet
+
+	// Section-specific functions.  These require either firstSection() or
+	// nextSection() to have run successfully before they will return valid
+	// data.
+	uint32_t getSectionMonitorID() const;
+	uint32_t getSectionEventCount() const;
+	uint32_t getSectionSourceID() const;
+	uint32_t getSectionTOFOffset() const;
+	bool sectionTOFCorrected() const;
+	bool nextEvent(bool &risingEdge, uint32_t &cycle, uint32_t &tof) const;
 
 private:
 	const uint32_t *m_fields;
+
+	// Data about the current monitor section
+	mutable uint32_t m_sectionStartIndex;	// index into m_fields for the start of this section
+	mutable uint32_t m_eventNum;		// used to keep nextEvent from running past the end of the section
 
 	BeamMonitorPkt(const uint8_t *data, uint32_t len);
 
@@ -328,8 +369,8 @@ public:
 	PixelMappingPkt(const PixelMappingPkt &pkt);
 
 	// TODO implement accessors for fields
-	const uint8_t *mappingData(void) const {
-		return( (const uint8_t *) &(m_fields[0]) );
+	const uint8_t *mappingData() const {
+		return( reinterpret_cast<const uint8_t *>(&(m_fields[0])) );
 	}
 
 private:
@@ -345,9 +386,9 @@ public:
 	PixelMappingAltPkt(const PixelMappingAltPkt &pkt);
 
 	// TODO implement accessors for fields
-	uint32_t numBanks(void) const { return m_fields[0]; }
-	const uint8_t *mappingData(void) const {
-		return( (const uint8_t *) &(m_fields[1]) );
+	uint32_t numBanks() const { return m_fields[0]; }
+	const uint8_t *mappingData() const {
+		return( reinterpret_cast<const uint8_t *>(&(m_fields[1])) );
 	}
 
 private:
@@ -362,10 +403,10 @@ class RunStatusPkt : public Packet {
 public:
 	RunStatusPkt(const RunStatusPkt &pkt);
 
-	uint32_t runNumber(void) const { return m_fields[0]; }
-	uint32_t runStart(void) const { return m_fields[1]; }
-	uint32_t fileNumber(void) const { return m_fields[2] & 0xffffff; }
-	RunStatus::Enum status(void) const {
+	uint32_t runNumber() const { return m_fields[0]; }
+	uint32_t runStart() const { return m_fields[1]; }
+	uint32_t fileNumber() const { return m_fields[2] & 0xffffff; }
+	RunStatus::Enum status() const {
 		return static_cast<RunStatus::Enum>(m_fields[2] >> 24);
 	}
 
@@ -375,25 +416,25 @@ public:
 		field[1] = runStart;
 	}
 
-	uint32_t pauseFileNumber(void) const {
+	uint32_t pauseFileNumber() const {
 		if ( m_version >= 0x01 ) {
 			return m_fields[3] & 0xffffff;
 		}
 		else return( 0 );
 	}
-	uint32_t paused(void) const {
+	uint32_t paused() const {
 		if ( m_version >= 0x01 ) {
 			return m_fields[3] >> 24;
 		}
 		else return( 0 );
 	}
-	uint32_t addendumFileNumber(void) const {
+	uint32_t addendumFileNumber() const {
 		if ( m_version >= 0x01 ) {
 			return m_fields[4] & 0xffffff;
 		}
 		else return( 0 );
 	}
-	uint32_t addendum(void) const {
+	uint32_t addendum() const {
 		if ( m_version >= 0x01 ) {
 			return m_fields[4] >> 24;
 		}
@@ -412,7 +453,7 @@ class RunInfoPkt : public Packet {
 public:
 	RunInfoPkt(const RunInfoPkt &pkt);
 
-	const std::string &info(void) const { return m_xml; }
+	const std::string &info() const { return m_xml; }
 
 private:
 	std::string m_xml;
@@ -426,8 +467,8 @@ class TransCompletePkt : public Packet {
 public:
 	TransCompletePkt(const TransCompletePkt &pkt);
 
-	uint16_t status(void) const { return m_status; }
-	const std::string &reason(void) const { return m_reason; }
+	uint16_t status() const { return m_status; }
+	const std::string &reason() const { return m_reason; }
 
 private:
 	uint16_t m_status;
@@ -448,8 +489,8 @@ public:
 		SEND_PAUSE_DATA   = 0x0002,
 	};
 
-	uint32_t requestedStartTime(void) const { return m_reqStart; }
-	uint32_t clientFlags(void) const { return m_clientFlags; }
+	uint32_t requestedStartTime() const { return m_reqStart; }
+	uint32_t clientFlags() const { return m_clientFlags; }
 
 private:
 	uint32_t m_reqStart;
@@ -464,15 +505,15 @@ class AnnotationPkt : public Packet {
 public:
 	AnnotationPkt(const AnnotationPkt &pkt);
 
-	bool resetHint(void) const { return !!(m_fields[0] & 0x80000000); }
-	MarkerType::Enum marker_type(void) const {
+	bool resetHint() const { return !!(m_fields[0] & 0x80000000); }
+	MarkerType::Enum marker_type() const {
 		uint16_t type = (m_fields[0] >> 16) & 0x7fff;
 		return static_cast<MarkerType::Enum>(type);
 	}
-	uint32_t scanIndex(void) const { return m_fields[1]; }
-	const std::string &comment(void) const {
+	uint32_t scanIndex() const { return m_fields[1]; }
+	const std::string &comment() const {
 		if (!m_comment.length() && (m_fields[0] & 0xffff)) {
-			m_comment.assign((const char *) &m_fields[2],
+			m_comment.assign(reinterpret_cast<const char *>(&m_fields[2]),
 					 m_fields[0] & 0xffff);
 		}
 
@@ -492,9 +533,9 @@ class SyncPkt : public Packet {
 public:
 	SyncPkt(const SyncPkt &pkt);
 
-	const std::string signature(void) const { return m_signature; }
-	uint64_t fileOffset(void) const { return m_offset; }
-	const std::string comment(void) const { return m_comment; }
+	const std::string signature() const { return m_signature; }
+	uint64_t fileOffset() const { return m_offset; }
+	const std::string comment() const { return m_comment; }
 
 private:
 	const uint32_t *m_fields;
@@ -521,7 +562,7 @@ class GeometryPkt : public Packet {
 public:
 	GeometryPkt(const GeometryPkt &pkt);
 
-	const std::string &info(void) const { return m_xml; }
+	const std::string &info() const { return m_xml; }
 
 private:
 	std::string m_xml;
@@ -535,12 +576,12 @@ class BeamlineInfoPkt : public Packet {
 public:
 	BeamlineInfoPkt(const BeamlineInfoPkt &pkt);
 
-	const uint32_t &targetStationNumber(void) const
+	const uint32_t &targetStationNumber() const
 		{ return m_targetStationNumber; }
 
-	const std::string &id(void) const { return m_id; }
-	const std::string &shortName(void) const { return m_shortName; }
-	const std::string &longName(void) const { return m_longName; }
+	const std::string &id() const { return m_id; }
+	const std::string &shortName() const { return m_shortName; }
+	const std::string &longName() const { return m_longName; }
 
 private:
 	uint32_t m_targetStationNumber;
@@ -563,13 +604,13 @@ class BeamMonitorConfigPkt : public Packet {
 public:
 	BeamMonitorConfigPkt(const BeamMonitorConfigPkt &pkt);
 
-	uint32_t beamMonCount(void) const { return m_fields[0]; }
+	uint32_t beamMonCount() const { return m_fields[0]; }
 
 	uint32_t bmonId(uint32_t index) const
 	{
 		if ( index < beamMonCount() ) {
 			const uint32_t *section =
-				(const uint32_t *) ( ((const char *) m_fields)
+				reinterpret_cast<const uint32_t *>( reinterpret_cast<const char *>(m_fields)
 					+ sizeof(uint32_t) + ( index * m_sectionSize ) );
 			return( section[0] );
 		}
@@ -581,7 +622,7 @@ public:
 	{
 		if ( index < beamMonCount() ) {
 			const uint32_t *section =
-				(const uint32_t *) ( ((const char *) m_fields)
+				reinterpret_cast<const uint32_t *>( reinterpret_cast<const char *>(m_fields)
 					+ sizeof(uint32_t) + ( index * m_sectionSize ) );
 			return( section[1] );
 		}
@@ -593,7 +634,7 @@ public:
 	{
 		if ( index < beamMonCount() ) {
 			const uint32_t *section =
-				(const uint32_t *) ( ((const char *) m_fields)
+				reinterpret_cast<const uint32_t *>( reinterpret_cast<const char *>(m_fields)
 					+ sizeof(uint32_t) + ( index * m_sectionSize ) );
 			return( section[2] );
 		}
@@ -605,7 +646,7 @@ public:
 	{
 		if ( index < beamMonCount() ) {
 			const uint32_t *section =
-				(const uint32_t *) ( ((const char *) m_fields)
+				reinterpret_cast<const uint32_t *>( reinterpret_cast<const char *>(m_fields)
 					+ sizeof(uint32_t) + ( index * m_sectionSize ) );
 			return( section[3] );
 		}
@@ -617,9 +658,9 @@ public:
 	{
 		if ( index < beamMonCount() ) {
 			const uint32_t *section =
-				(const uint32_t *) ( ((const char *) m_fields)
+				reinterpret_cast<const uint32_t *>( reinterpret_cast<const char *>(m_fields)
 					+ sizeof(uint32_t) + ( index * m_sectionSize ) );
-			return( *( (const double *) &(section[4]) ) );
+			return( *( reinterpret_cast<const double *>(&(section[4])) ) );
 		}
 		else
 			return( 0.0 );
@@ -634,7 +675,7 @@ public:
 			if ( index < beamMonCount() ) {
 				// Trailing "Format Appendix" Section... ;-b
 				const uint32_t *format_section =
-					(const uint32_t *) ( ((const char *) m_fields)
+					reinterpret_cast<const uint32_t *>( reinterpret_cast<const char *>(m_fields)
 						+ sizeof(uint32_t)
 						+ ( beamMonCount() * m_sectionSize ) );
 				return( format_section[ index ] );
@@ -682,7 +723,7 @@ public:
 	// Throttle Suffix, alphanumeric, no spaces/punctuation...
 	static const size_t THROTTLE_SUFFIX_SIZE = 16;
 
-	uint32_t detBankSetCount(void) const { return m_fields[0]; }
+	uint32_t detBankSetCount() const { return m_fields[0]; }
 
 	uint32_t sectionOffset(uint32_t index) const
 	{
@@ -696,9 +737,9 @@ public:
 	{
 		if ( index < detBankSetCount() ) {
 			char name_c[SET_NAME_SIZE + 1];   // give them an inch...
-			memset( (void *) name_c, '\0', SET_NAME_SIZE + 1 );
+			memset( reinterpret_cast<void *>(name_c), '\0', SET_NAME_SIZE + 1 );
 			strncpy(name_c,
-				(const char *) &(m_fields[ m_sectionOffsets[index] ]),
+				reinterpret_cast<const char *>(&(m_fields[ m_sectionOffsets[index] ])),
 				SET_NAME_SIZE);
 			return( std::string(name_c) );
 		} else {
@@ -725,12 +766,12 @@ public:
 	const uint32_t *banklist(uint32_t index) const
 	{
 		if ( index < detBankSetCount() ) {
-			return (const uint32_t *) &m_fields[ m_sectionOffsets[index]
-				+ m_name_offset + 2 ];
+			return reinterpret_cast<const uint32_t *>(&m_fields[ m_sectionOffsets[index]
+				+ m_name_offset + 2 ]);
 		}
 		else {
 			// Shouldn't be asking for this if bankCount() returned 0...!
-			return( (const uint32_t *) NULL );
+			return( (const uint32_t *)nullptr );
 		}
 	}
 
@@ -761,8 +802,8 @@ public:
 	double throttle(uint32_t index) const
 	{
 		if ( index < detBankSetCount() ) {
-			return *(const double *) &m_fields[
-				m_after_banks_offset[index] + 3 ];
+			return *reinterpret_cast<const double *>(&m_fields[
+				m_after_banks_offset[index] + 3 ]);
 		}
 		else
 			return( 0.0 );
@@ -772,9 +813,9 @@ public:
 	{
 		if ( index < detBankSetCount() ) {
 			char suffix_c[THROTTLE_SUFFIX_SIZE + 1];   // give them an inch
-			memset( (void *) suffix_c, '\0', THROTTLE_SUFFIX_SIZE + 1 );
+			memset( reinterpret_cast<void *>(suffix_c), '\0', THROTTLE_SUFFIX_SIZE + 1 );
 			strncpy(suffix_c,
-				(const char *) &(m_fields[m_after_banks_offset[index] + 5]),
+				reinterpret_cast<const char *>(&(m_fields[m_after_banks_offset[index] + 5])),
 				THROTTLE_SUFFIX_SIZE);
 			return( std::string(suffix_c) );
 		} else {
@@ -817,11 +858,11 @@ class DeviceDescriptorPkt : public Packet {
 public:
 	DeviceDescriptorPkt(const DeviceDescriptorPkt &pkt);
 
-	uint32_t devId(void) const { return m_devId; }
-	const std::string &description(void) const { return m_desc; }
+	uint32_t devId() const { return m_devId; }
+	const std::string &description() const { return m_desc; }
 
 	void remapDeviceId(uint32_t dev) {
-		uint32_t *fields = (uint32_t *)const_cast<uint8_t *>(payload());
+		uint32_t *fields = reinterpret_cast<uint32_t *>(const_cast<uint8_t *>(payload()));
 	        fields[0] = dev;
 		m_devId = dev;
 	};
@@ -839,19 +880,19 @@ class VariableU32Pkt : public Packet {
 public:
 	VariableU32Pkt(const VariableU32Pkt &pkt);
 
-	uint32_t devId(void) const { return m_fields[0]; }
-	uint32_t varId(void) const { return m_fields[1]; }
-	VariableStatus::Enum status(void) const {
+	uint32_t devId() const { return m_fields[0]; }
+	uint32_t varId() const { return m_fields[1]; }
+	VariableStatus::Enum status() const {
 		return static_cast<VariableStatus::Enum> (m_fields[2] >> 16);
 	}
-	VariableSeverity::Enum severity(void) const {
+	VariableSeverity::Enum severity() const {
 		return static_cast<VariableSeverity::Enum>
 							(m_fields[2] & 0xffff);
 	}
-	uint32_t value(void) const { return m_fields[3]; }
+	uint32_t value() const { return m_fields[3]; }
 
 	void remapDeviceId(uint32_t dev) {
-		uint32_t *fields = (uint32_t *)const_cast<uint8_t *>(payload());
+		uint32_t *fields = reinterpret_cast<uint32_t *>(const_cast<uint8_t *>(payload()));
 		fields[0] = dev;
 	};
 
@@ -867,25 +908,25 @@ class VariableDoublePkt : public Packet {
 public:
 	VariableDoublePkt(const VariableDoublePkt &pkt);
 
-	uint32_t devId(void) const { return m_fields[0]; }
-	uint32_t varId(void) const { return m_fields[1]; }
-	VariableStatus::Enum status(void) const {
+	uint32_t devId() const { return m_fields[0]; }
+	uint32_t varId() const { return m_fields[1]; }
+	VariableStatus::Enum status() const {
 		return static_cast<VariableStatus::Enum> (m_fields[2] >> 16);
 	}
-	VariableSeverity::Enum severity(void) const {
+	VariableSeverity::Enum severity() const {
 		return static_cast<VariableSeverity::Enum>
 							(m_fields[2] & 0xffff);
 	}
-	double value(void) const { return *((const double *) &m_fields[3]); }
+	double value() const { return *reinterpret_cast<const double *>(&m_fields[3]); }
 
 	void remapDeviceId(uint32_t dev) {
-		uint32_t *fields = (uint32_t *)const_cast<uint8_t *>(payload());
+		uint32_t *fields = reinterpret_cast<uint32_t *>(const_cast<uint8_t *>(payload()));
 		fields[0] = dev;
 	};
 
 	void updateValue(double value) {
-		uint32_t *fields = (uint32_t *)const_cast<uint8_t *>(payload());
-		*((double *) &fields[3]) = value;
+		uint32_t *fields = reinterpret_cast<uint32_t *>(const_cast<uint8_t *>(payload()));
+		*reinterpret_cast<double *>(&fields[3]) = value;
 	};
 
 	VariableDoublePkt(const uint8_t *data, uint32_t len);
@@ -900,19 +941,19 @@ class VariableStringPkt : public Packet {
 public:
 	VariableStringPkt(const VariableStringPkt &pkt);
 
-	uint32_t devId(void) const { return m_fields[0]; }
-	uint32_t varId(void) const { return m_fields[1]; }
-	VariableStatus::Enum status(void) const {
+	uint32_t devId() const { return m_fields[0]; }
+	uint32_t varId() const { return m_fields[1]; }
+	VariableStatus::Enum status() const {
 		return static_cast<VariableStatus::Enum> (m_fields[2] >> 16);
 	}
-	VariableSeverity::Enum severity(void) const {
+	VariableSeverity::Enum severity() const {
 		return static_cast<VariableSeverity::Enum>
 						(m_fields[2] & 0xffff);
 	}
-	const std::string &value(void) const { return m_val; }
+	const std::string &value() const { return m_val; }
 
 	void remapDeviceId(uint32_t dev) {
-		uint32_t *fields = (uint32_t *)const_cast<uint8_t *>(payload());
+		uint32_t *fields = reinterpret_cast<uint32_t *>(const_cast<uint8_t *>(payload()));
 		fields[0] = dev;
 	};
 
@@ -929,20 +970,20 @@ class VariableU32ArrayPkt : public Packet {
 public:
 	VariableU32ArrayPkt(const VariableU32ArrayPkt &pkt);
 
-	uint32_t devId(void) const { return m_fields[0]; }
-	uint32_t varId(void) const { return m_fields[1]; }
-	VariableStatus::Enum status(void) const {
+	uint32_t devId() const { return m_fields[0]; }
+	uint32_t varId() const { return m_fields[1]; }
+	VariableStatus::Enum status() const {
 		return static_cast<VariableStatus::Enum> (m_fields[2] >> 16);
 	}
-	VariableSeverity::Enum severity(void) const {
+	VariableSeverity::Enum severity() const {
 		return static_cast<VariableSeverity::Enum>
 							(m_fields[2] & 0xffff);
 	}
-	uint32_t elemCount(void) const { return m_fields[3]; }
-	const std::vector<uint32_t> &value(void) const { return m_val; }
+	uint32_t elemCount() const { return m_fields[3]; }
+	const std::vector<uint32_t> &value() const { return m_val; }
 
 	void remapDeviceId(uint32_t dev) {
-		uint32_t *fields = (uint32_t *)const_cast<uint8_t *>(payload());
+		uint32_t *fields = reinterpret_cast<uint32_t *>(const_cast<uint8_t *>(payload()));
 		fields[0] = dev;
 	};
 
@@ -959,20 +1000,20 @@ class VariableDoubleArrayPkt : public Packet {
 public:
 	VariableDoubleArrayPkt(const VariableDoubleArrayPkt &pkt);
 
-	uint32_t devId(void) const { return m_fields[0]; }
-	uint32_t varId(void) const { return m_fields[1]; }
-	VariableStatus::Enum status(void) const {
+	uint32_t devId() const { return m_fields[0]; }
+	uint32_t varId() const { return m_fields[1]; }
+	VariableStatus::Enum status() const {
 		return static_cast<VariableStatus::Enum> (m_fields[2] >> 16);
 	}
-	VariableSeverity::Enum severity(void) const {
+	VariableSeverity::Enum severity() const {
 		return static_cast<VariableSeverity::Enum>
 							(m_fields[2] & 0xffff);
 	}
-	uint32_t elemCount(void) const { return m_fields[3]; }
-	const std::vector<double> &value(void) const { return m_val; }
+	uint32_t elemCount() const { return m_fields[3]; }
+	const std::vector<double> &value() const { return m_val; }
 
 	void remapDeviceId(uint32_t dev) {
-		uint32_t *fields = (uint32_t *)const_cast<uint8_t *>(payload());
+		uint32_t *fields = reinterpret_cast<uint32_t *>(const_cast<uint8_t *>(payload()));
 		fields[0] = dev;
 	};
 
@@ -989,21 +1030,21 @@ class MultVariableU32Pkt : public Packet {
 public:
 	MultVariableU32Pkt(const MultVariableU32Pkt &pkt);
 
-	uint32_t devId(void) const { return m_fields[0]; }
-	uint32_t varId(void) const { return m_fields[1]; }
-	VariableStatus::Enum status(void) const {
+	uint32_t devId() const { return m_fields[0]; }
+	uint32_t varId() const { return m_fields[1]; }
+	VariableStatus::Enum status() const {
 		return static_cast<VariableStatus::Enum> (m_fields[2] >> 16);
 	}
-	VariableSeverity::Enum severity(void) const {
+	VariableSeverity::Enum severity() const {
 		return static_cast<VariableSeverity::Enum>
 							(m_fields[2] & 0xffff);
 	}
-	uint32_t numValues(void) const { return m_fields[3]; }
-	const std::vector<uint32_t> &values(void) const { return m_vals; }
-	const std::vector<uint32_t> &tofs(void) const { return m_tofs; }
+	uint32_t numValues() const { return m_fields[3]; }
+	const std::vector<uint32_t> &values() const { return m_vals; }
+	const std::vector<uint32_t> &tofs() const { return m_tofs; }
 
 	void remapDeviceId(uint32_t dev) {
-		uint32_t *fields = (uint32_t *)const_cast<uint8_t *>(payload());
+		uint32_t *fields = reinterpret_cast<uint32_t *>(const_cast<uint8_t *>(payload()));
 		fields[0] = dev;
 	};
 
@@ -1021,27 +1062,27 @@ class MultVariableDoublePkt : public Packet {
 public:
 	MultVariableDoublePkt(const MultVariableDoublePkt &pkt);
 
-	uint32_t devId(void) const { return m_fields[0]; }
-	uint32_t varId(void) const { return m_fields[1]; }
-	VariableStatus::Enum status(void) const {
+	uint32_t devId() const { return m_fields[0]; }
+	uint32_t varId() const { return m_fields[1]; }
+	VariableStatus::Enum status() const {
 		return static_cast<VariableStatus::Enum> (m_fields[2] >> 16);
 	}
-	VariableSeverity::Enum severity(void) const {
+	VariableSeverity::Enum severity() const {
 		return static_cast<VariableSeverity::Enum>
 							(m_fields[2] & 0xffff);
 	}
-	uint32_t numValues(void) const { return m_fields[3]; }
-	const std::vector<double> &values(void) const { return m_vals; }
-	const std::vector<uint32_t> &tofs(void) const { return m_tofs; }
+	uint32_t numValues() const { return m_fields[3]; }
+	const std::vector<double> &values() const { return m_vals; }
+	const std::vector<uint32_t> &tofs() const { return m_tofs; }
 
 	void remapDeviceId(uint32_t dev) {
-		uint32_t *fields = (uint32_t *)const_cast<uint8_t *>(payload());
+		uint32_t *fields = reinterpret_cast<uint32_t *>(const_cast<uint8_t *>(payload()));
 		fields[0] = dev;
 	};
 
 	void updateValue(double value) {
-		uint32_t *fields = (uint32_t *)const_cast<uint8_t *>(payload());
-		*((double *) &fields[3]) = value;
+		uint32_t *fields = reinterpret_cast<uint32_t *>(const_cast<uint8_t *>(payload()));
+		*reinterpret_cast<double *>(&fields[3]) = value;
 	};
 
 	MultVariableDoublePkt(const uint8_t *data, uint32_t len);
@@ -1058,21 +1099,21 @@ class MultVariableStringPkt : public Packet {
 public:
 	MultVariableStringPkt(const MultVariableStringPkt &pkt);
 
-	uint32_t devId(void) const { return m_fields[0]; }
-	uint32_t varId(void) const { return m_fields[1]; }
-	VariableStatus::Enum status(void) const {
+	uint32_t devId() const { return m_fields[0]; }
+	uint32_t varId() const { return m_fields[1]; }
+	VariableStatus::Enum status() const {
 		return static_cast<VariableStatus::Enum> (m_fields[2] >> 16);
 	}
-	VariableSeverity::Enum severity(void) const {
+	VariableSeverity::Enum severity() const {
 		return static_cast<VariableSeverity::Enum>
 						(m_fields[2] & 0xffff);
 	}
-	uint32_t numValues(void) const { return m_fields[3]; }
-	const std::vector<std::string> &values(void) const { return m_vals; }
-	const std::vector<uint32_t> &tofs(void) const { return m_tofs; }
+	uint32_t numValues() const { return m_fields[3]; }
+	const std::vector<std::string> &values() const { return m_vals; }
+	const std::vector<uint32_t> &tofs() const { return m_tofs; }
 
 	void remapDeviceId(uint32_t dev) {
-		uint32_t *fields = (uint32_t *)const_cast<uint8_t *>(payload());
+		uint32_t *fields = reinterpret_cast<uint32_t *>(const_cast<uint8_t *>(payload()));
 		fields[0] = dev;
 	};
 
@@ -1090,26 +1131,26 @@ class MultVariableU32ArrayPkt : public Packet {
 public:
 	MultVariableU32ArrayPkt(const MultVariableU32ArrayPkt &pkt);
 
-	uint32_t devId(void) const { return m_fields[0]; }
-	uint32_t varId(void) const { return m_fields[1]; }
-	VariableStatus::Enum status(void) const {
+	uint32_t devId() const { return m_fields[0]; }
+	uint32_t varId() const { return m_fields[1]; }
+	VariableStatus::Enum status() const {
 		return static_cast<VariableStatus::Enum> (m_fields[2] >> 16);
 	}
-	VariableSeverity::Enum severity(void) const {
+	VariableSeverity::Enum severity() const {
 		return static_cast<VariableSeverity::Enum>
 							(m_fields[2] & 0xffff);
 	}
-	uint32_t numValues(void) const { return m_fields[3]; }
+	uint32_t numValues() const { return m_fields[3]; }
 	uint32_t elemCount(uint32_t index) const {
 		return( ( index < numValues() ) ? m_vals[index].size() : 0 );
 	}
-	const std::vector<std::vector<uint32_t> > values(void) const {
+	const std::vector<std::vector<uint32_t> > values() const {
 		return m_vals;
 	}
-	const std::vector<uint32_t> &tofs(void) const { return m_tofs; }
+	const std::vector<uint32_t> &tofs() const { return m_tofs; }
 
 	void remapDeviceId(uint32_t dev) {
-		uint32_t *fields = (uint32_t *)const_cast<uint8_t *>(payload());
+		uint32_t *fields = reinterpret_cast<uint32_t *>(const_cast<uint8_t *>(payload()));
 		fields[0] = dev;
 	};
 
@@ -1127,26 +1168,26 @@ class MultVariableDoubleArrayPkt : public Packet {
 public:
 	MultVariableDoubleArrayPkt(const MultVariableDoubleArrayPkt &pkt);
 
-	uint32_t devId(void) const { return m_fields[0]; }
-	uint32_t varId(void) const { return m_fields[1]; }
-	VariableStatus::Enum status(void) const {
+	uint32_t devId() const { return m_fields[0]; }
+	uint32_t varId() const { return m_fields[1]; }
+	VariableStatus::Enum status() const {
 		return static_cast<VariableStatus::Enum> (m_fields[2] >> 16);
 	}
-	VariableSeverity::Enum severity(void) const {
+	VariableSeverity::Enum severity() const {
 		return static_cast<VariableSeverity::Enum>
 							(m_fields[2] & 0xffff);
 	}
-	uint32_t numValues(void) const { return m_fields[3]; }
+	uint32_t numValues() const { return m_fields[3]; }
 	uint32_t elemCount(uint32_t index) const {
 		return( ( index < numValues() ) ? m_vals[index].size() : 0 );
 	}
-	const std::vector<std::vector<double> > values(void) const {
+	const std::vector<std::vector<double> > values() const {
 		return m_vals;
 	}
-	const std::vector<uint32_t> &tofs(void) const { return m_tofs; }
+	const std::vector<uint32_t> &tofs() const { return m_tofs; }
 
 	void remapDeviceId(uint32_t dev) {
-		uint32_t *fields = (uint32_t *)const_cast<uint8_t *>(payload());
+		uint32_t *fields = reinterpret_cast<uint32_t *>(const_cast<uint8_t *>(payload()));
 		fields[0] = dev;
 	};
 

--- a/common/ADARAParser.cc
+++ b/common/ADARAParser.cc
@@ -57,7 +57,7 @@ Parser::~Parser()
 	delete [] m_buffer;
 }
 
-void Parser::reset(void)
+void Parser::reset()
 {
 	m_len = 0;
 	m_restart_offset = 0;
@@ -98,7 +98,7 @@ int Parser::bufferParse(std::string & log_info, unsigned int max_packets)
 		chunk_len = m_oversize_len;
 		if (valid_len < chunk_len)
 			chunk_len = valid_len;
-		stopped = rxOversizePkt(NULL, p, m_oversize_offset, chunk_len);
+		stopped = rxOversizePkt(nullptr, p, m_oversize_offset, chunk_len);
 		m_oversize_offset += chunk_len;
 		m_oversize_len -= chunk_len;
 		valid_len -= chunk_len;
@@ -220,7 +220,7 @@ int Parser::bufferParse(std::string & log_info, unsigned int max_packets)
 			/* We know that the offset will fit into an unsigned
 			 * int, as that is the type we use for the buffer size.
 			 */
-			m_restart_offset = (unsigned int) (p - m_buffer);
+			m_restart_offset = static_cast<unsigned int>(p - m_buffer);
 		}
 	} else {
 		/* We used up the buffer. */
@@ -236,7 +236,7 @@ int Parser::bufferParse(std::string & log_info, unsigned int max_packets)
 	int rc;
 	
 	if ( stopped ) {
-		rc = - (int) processed;
+		rc = -static_cast<int>(processed);
 		// add to "stopped" log info...
 		ss << processed;
 		log_info.append("had parsed ");
@@ -244,7 +244,7 @@ int Parser::bufferParse(std::string & log_info, unsigned int max_packets)
 		log_info.append(" packets; ");
 	}
 	else {
-		rc = (int) processed;
+		rc = static_cast<int>(processed);
 		// create log info...
 		ss << rc;
 		log_info.append("bufferParse(): Done. Parsed ");
@@ -324,7 +324,7 @@ bool Parser::rxOversizePkt(const PacketHeader *hdr, const uint8_t *,
 {
 	// NOTE: ADARA::PacketHeader *hdr can be NULL...! ;-o
 	/* Default is to discard the data */
-	if (hdr != NULL)
+	if (hdr != nullptr)
 		(m_discarded_packets[hdr->base_type()])++;
 	return false;
 }
@@ -373,16 +373,14 @@ void Parser::getDiscardedPacketsLogString(std::string & log_info)
 	uint64_t total_discarded = 0;
 
 	// Append Each Discarded Packet Type Count...
-	for (std::map<PacketType::Type, uint64_t>::iterator
-			it = m_discarded_packets.begin();
-			it != m_discarded_packets.end(); it++)
+	for (const auto &discarded_packet : m_discarded_packets)
 	{
 		std::stringstream ss;
-		ss << std::hex << "0x" << it->first << std::dec
-			<< "=" << it->second << "; ";
+		ss << std::hex << "0x" << discarded_packet.first << std::dec
+			<< "=" << discarded_packet.second << "; ";
 		log_info.append(ss.str());
 
-		total_discarded += it->second;
+		total_discarded += discarded_packet.second;
 	}
 
 	// Append Total Discarded Packet Count
@@ -391,7 +389,7 @@ void Parser::getDiscardedPacketsLogString(std::string & log_info)
 	log_info.append(ss.str());
 }
 
-void Parser::resetDiscardedPacketsStats(void)
+void Parser::resetDiscardedPacketsStats()
 {
 	// Reset Associative Map, Start Clean Stats...
 	m_discarded_packets.clear();

--- a/common/ADARAParser.h
+++ b/common/ADARAParser.h
@@ -67,13 +67,13 @@ protected:
 	 * must call bufferBytesAppended() to inform the class how much
 	 * new data has been placed in the buffer.
 	 */
-	uint8_t *bufferFillAddress(void) const {
+	uint8_t *bufferFillAddress() const {
 		if (bufferFillLength())
 			return m_buffer + m_len;
-		return NULL;
+		return nullptr;
 	}
 
-	unsigned int bufferFillLength(void) const {
+	unsigned int bufferFillLength() const {
 		return m_size - m_len;
 	}
 
@@ -103,7 +103,7 @@ protected:
 
 	/* Flush the internal buffers and get ready to restart parsing.
 	 */
-	virtual void reset(void);
+	virtual void reset();
 
 	/* This function gets called for every packet that fits in the
 	 * internal buffer; oversize packets will be sent to rxOversizePkt().
@@ -178,7 +178,7 @@ protected:
 
 	/* Reset the collected "discarded packet" statistics.
 	 */
-	void resetDiscardedPacketsStats(void);
+	void resetDiscardedPacketsStats();
 
 private:
 	uint8_t *	m_buffer;


### PR DESCRIPTION
# Pull in updates from Mantid
Syncs common/ with the upstream Mantid copy of the ADARA parser, bringing in functionality and modernization that had diverged.

## Functional changes
BankedEventPkt: implemented the previously-stubbed bank/event accessors. Adds firstEvent() / nextEvent() iteration with per-source and per-bank state tracking (curBankId(), curEventCount(), getSourceCORFlag(), getSourceTOFOffset()), backed by the firstEventInSource() / firstEventInBank() helpers. Replaces the old // TODO implement bank/event accessors placeholder.
BeamMonitorPkt: implemented monitor/event accessors. Adds section iteration via nextSection() plus getSectionMonitorID(), getSectionEventCount(), getSectionSourceID(), getSectionTOFOffset(), sectionTOFCorrected(), and per-event nextEvent(risingEdge, cycle, tof).
## Modernization (no behavior change)
Replaced C-style casts with reinterpret_cast / static_cast throughout the packet and parser code.
NULL → nullptr.
Dropped redundant (void) argument lists on member functions.
Converted an iterator-based loop over m_discarded_packets to a range-based for.
### Files
common/ADARAPackets.h, common/ADARAPackets.cc — packet accessor implementations + modernization
common/ADARAParser.h, common/ADARAParser.cc — modernization only

### Testing
Make sure adara still builds.